### PR TITLE
Add read-only Leads API endpoint

### DIFF
--- a/backend/MiniCrm.Api/Program.cs
+++ b/backend/MiniCrm.Api/Program.cs
@@ -67,6 +67,23 @@ app.MapGet("/weatherforecast", () =>
 })
 .WithName("GetWeatherForecast");
 
+// ======================
+// Leads Endpoint (read-only demo)
+// ======================
+
+app.MapGet("/api/leads", () =>
+{
+    var leads = new[]
+    {
+        new { id = 1, name = "Max Mustermann", email = "max@example.com" },
+        new { id = 2, name = "Erika Musterfrau", email = "erika@example.com" },
+    };
+
+    return Results.Ok(leads);
+})
+.WithName("GetLeads");
+
+
 app.Run();
 
 // ======================


### PR DESCRIPTION
Adds a first read-only leads endpoint to the backend API.

- GET /api/leads returns demo data (no database yet)

Closes #18
